### PR TITLE
Using GitHub Action to run all unit tests automatically when a PR is created or a Commit is pushed.

### DIFF
--- a/.github/workflows/scala-test.yml
+++ b/.github/workflows/scala-test.yml
@@ -2,9 +2,9 @@ name: Scala Test CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develope, ci-unit-testing ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develope ]
 
 jobs:
   build:

--- a/.github/workflows/scala-test.yml
+++ b/.github/workflows/scala-test.yml
@@ -17,13 +17,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Setup Maven
-        # You may pin to the exact commit or the version.
-        # uses: stCarolas/setup-maven@1d56b37995622db66cce1214d81014b09807fb5a
-        uses: stCarolas/setup-maven@v4
+      - name: Restore Maven cache
+        uses: skjolber/maven-cache-github-action@v1
         with:
-          # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0
-          maven-version: 3.5.4
-      - name: Run tests
+          step: restore
+      - name: Run scalatest with Maven
         run: mvn test
+      - name: Save Maven cache
+        uses: skjolber/maven-cache-github-action@v1
+        with:
+          step: save
 

--- a/.github/workflows/scala-test.yml
+++ b/.github/workflows/scala-test.yml
@@ -2,7 +2,7 @@ name: Scala Test CI
 
 on:
   push:
-    branches: [ master, develope, ci-unit-testing ]
+    branches: [ master, develope, ci-unit-testings ]
   pull_request:
     branches: [ master, develope ]
 

--- a/.github/workflows/scala-test.yml
+++ b/.github/workflows/scala-test.yml
@@ -1,0 +1,29 @@
+name: Scala Test CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Setup Maven
+        # You may pin to the exact commit or the version.
+        # uses: stCarolas/setup-maven@1d56b37995622db66cce1214d81014b09807fb5a
+        uses: stCarolas/setup-maven@v4
+        with:
+          # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0
+          maven-version: 3.5.4
+      - name: Run tests
+        run: mvn test
+

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,29 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- enable scalatest -->
+            <plugin>
+              <groupId>org.scalatest</groupId>
+              <artifactId>scalatest-maven-plugin</artifactId>
+              <version>1.0</version>
+              <configuration>
+                <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                <junitxml>.</junitxml>
+                <filereports>WDF TestSuite.txt</filereports>
+                <wildcardSuites>
+                    tests
+                </wildcardSuites>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>test</id>
+                  <goals>
+                    <goal>test</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/src/main/scala/tests/Y2Nk4_CI_Unit_Testings.scala
+++ b/src/main/scala/tests/Y2Nk4_CI_Unit_Testings.scala
@@ -1,0 +1,9 @@
+package tests
+
+import org.scalatest.FunSuite
+
+class Y2Nk4_CI_Unit_Testings extends FunSuite{
+  test("always_fail_test") {
+    assert(1 == 2)
+  }
+}

--- a/src/main/scala/tests/Y2Nk4_CI_Unit_Testings.scala
+++ b/src/main/scala/tests/Y2Nk4_CI_Unit_Testings.scala
@@ -1,9 +1,0 @@
-package tests
-
-import org.scalatest.FunSuite
-
-class Y2Nk4_CI_Unit_Testings extends FunSuite{
-  test("always_fail_test") {
-    assert(1 == 2)
-  }
-}


### PR DESCRIPTION
Using GitHub Action to run all unit tests automatically when a PR is created or a Commit is pushed. 
So we could know if a contribution passes all the testings before we begin to work on merging it.

I did serval testings with it, and confident that this is good to ship it:
- With all exist testing cases, the CI job ran with no problem. [Example here](https://github.com/Y2Nk4/RoboTA/actions/runs/680891291)
 
- `always_fail_case`: With a failed testing, the CI job will fail. [Example here](https://github.com/Y2Nk4/RoboTA/actions/runs/680876252)

Also, I used the [Maven Cache](https://github.com/marketplace/actions/maven-cache) Action, the redundant files will get cached when a job is done, so that the CI doesn't have to do redundant steps when it gets emitted. For example, it doesn't have to download Maven dependencies every time it runs, which hugely reduced the time the CI spends running through the testings.