### PR TITLE
Remove redundant sortByUpvotes, add cache copy for message, etc 

### DIFF
--- a/src/main/scala/model/QuestionListFunctions.scala
+++ b/src/main/scala/model/QuestionListFunctions.scala
@@ -4,14 +4,7 @@ object QuestionListFunctions {
 
   def percentageAnswered(qList: List[Question]): Double ={
     val boolList = qList.map(_.answered)
-    Math.floor(boolList.count(_ == true).toDouble / boolList.length * 100.0)
+    Math.floor(boolList.count(_ == true).toDouble / boolList.length * 10000.0) / 100
   }
-
-  def sortByUpvotes(qList: List[Question]): List[Question] ={
-    val upvoteList = qList.sortBy(_.numberOfUpvotes()).reverse
-    upvoteList
-  }
-
-
 
 }

--- a/src/main/scala/tests/QLFTesting.scala
+++ b/src/main/scala/tests/QLFTesting.scala
@@ -1,33 +1,29 @@
 package tests
 
+import model.Question
+import model.QuestionListFunctions
 import org.scalatest.FunSuite
-import model.{QuestionListFunctions, Question}
 
 class QLFTesting extends FunSuite{
-
-  test("Upvotes Empty List"){
-    val empty = List()
-    val output = QuestionListFunctions.sortByUpvotes(empty)
-    assert(output.equals(empty))
-  }
-
-  test("Upvotes In Order"){
+  test("percentage_answered"){
     val q1: Question = new Question("1","First?","first")
     val q2:Question = new Question("2", "Is this a question?", "second")
     q2.addUpvote("voter")
-    val output = QuestionListFunctions.sortByUpvotes(List(q1, q2)).map(_.displayId)
-    assert(output.equals(List("2","1")))
-  }
-
-  test("Upvotes Same Order"){
-    val q1: Question = new Question("1","First?","first")
-    val q2:Question = new Question("2", "Is this a question?", "second")
-    q2.addUpvote("voter")
-    val q3:Question = new Question("2", "Is this a better question?", "third")
+    val q3:Question = new Question("3", "Is this a better question?", "third")
     q3.addUpvote("voter")
     q3.addUpvote("voter")
-    val output = QuestionListFunctions.sortByUpvotes(List(q3, q2, q1)).map(_.displayId)
-    assert(output.equals(List("3","2","1")))
-  }
 
+    val questionList = List(q1, q2, q3)
+
+    var percentage = QuestionListFunctions.percentageAnswered(questionList)
+    println(percentage)
+
+    assert(TestHelper.compareDoubles(percentage, 0.0))
+
+    q1.answered = true
+
+    percentage = QuestionListFunctions.percentageAnswered(questionList)
+    println(percentage)
+    assert(TestHelper.compareDoubles(percentage, 33.33))
+  }
 }

--- a/src/main/scala/tests/TestHelper.scala
+++ b/src/main/scala/tests/TestHelper.scala
@@ -1,0 +1,9 @@
+package tests
+
+object TestHelper {
+  val EPSILON: Double = 0.00001
+
+  def compareDoubles(d1: Double, d2: Double): Boolean = {
+    Math.abs(d1 - d2) < EPSILON
+  }
+}

--- a/src/main/scala/webserver/Main.scala
+++ b/src/main/scala/webserver/Main.scala
@@ -10,12 +10,9 @@ import akka.actor.ActorRef
 
 
 object Main {
-  var webSocketServer: ActorRef = null
-  var twitchBotActor: ActorRef = null
-  var twitchAPIActor: ActorRef = null
 
   def main(args: Array[String]): Unit = {
-//    Dotenv.loadEnv()
+    Dotenv.loadEnv()
 
     val system: ActorSystem = ActorSystem("Web_System")
 
@@ -24,9 +21,9 @@ object Main {
 
     val database = new TestDatabase
 
-    webSocketServer = system.actorOf(Props(classOf[WebSocketServer], database))
-    twitchBotActor = system.actorOf(Props(classOf[TwitchBot], webSocketServer, database))
-    twitchAPIActor = system.actorOf(Props(classOf[TwitchAPI], twitchBotActor))
+    val webSocketServer = system.actorOf(Props(classOf[WebSocketServer]))
+    val twitchBotActor = system.actorOf(Props(classOf[TwitchBot], webSocketServer, database))
+    val twitchAPIActor = system.actorOf(Props(classOf[TwitchAPI], twitchBotActor))
 
     new WebServer()
 


### PR DESCRIPTION
This pr remove redundant sortByUpvotes, add unit testing for `percentageAnswered`.
Also, I change the WebSocketServer to maintain a cached copy for messages instead of asking the database for the whole question list every time a new client connects.